### PR TITLE
fix: resolve AttributeError on ASN field and remove unused json import

### DIFF
--- a/omnisci3nt/modules/urlscan.py
+++ b/omnisci3nt/modules/urlscan.py
@@ -2,7 +2,6 @@
 
 import requests
 import os
-import json
 
 R = "\033[31m"  # red
 G = "\033[32m"  # green
@@ -115,12 +114,10 @@ def run_urlscan(domain):
             ip_address = page.get("ip", "N/A")
             scan_data["ip_address"] = ip_address
 
-            # ASN information
+            # ASN information — urlscan.io returns asn and asnname as strings
             asn = page.get("asn", "N/A")
-            if asn:
-                asn_str = f"{asn.get('asnum', 'N/A')} ({asn.get('name', 'N/A')})"
-            else:
-                asn_str = "N/A"
+            asnname = page.get("asnname", "")
+            asn_str = f"{asn} ({asnname})" if asnname else asn
             scan_data["asn"] = asn_str
 
             # Country information


### PR DESCRIPTION

<img width="898" height="778" alt="Screenshot 2026-06-16 213800" src="https://github.com/user-attachments/assets/e36b37c9-e7b0-4253-81ef-48f697a1244c" />
 urlscan.io API returns page.asn and page.asnname as plain strings,
 not a nested dict. Calling .get() on a string caused:
   'str' object has no attribute 'get'

 Also removed unused 'import json' (flake8 F401).